### PR TITLE
[Lv.8] 과제 요구 기능(UI, Button Action) 구현 - 황도일

### DIFF
--- a/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.pbxproj
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		71B9EADD2CE70FEB0013F4BF /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 71B9EADC2CE70FEB0013F4BF /* SnapKit */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		7151D3FF2CE5970500620914 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -65,6 +69,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				71B9EADD2CE70FEB0013F4BF /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,6 +96,7 @@
 				7151D3EA2CE5970400620914 /* CalculatorApp-Codebase */,
 				7151D4012CE5970500620914 /* CalculatorApp-CodebaseTests */,
 				7151D40B2CE5970500620914 /* CalculatorApp-CodebaseUITests */,
+				71B9EADB2CE70FEB0013F4BF /* Frameworks */,
 				7151D3E92CE5970400620914 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -103,6 +109,13 @@
 				7151D4082CE5970500620914 /* CalculatorApp-CodebaseUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		71B9EADB2CE70FEB0013F4BF /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -125,6 +138,7 @@
 			);
 			name = "CalculatorApp-Codebase";
 			packageProductDependencies = (
+				71B9EADC2CE70FEB0013F4BF /* SnapKit */,
 			);
 			productName = "CalculatorApp-Codebase";
 			productReference = 7151D3E82CE5970400620914 /* CalculatorApp-Codebase.app */;
@@ -208,6 +222,9 @@
 			);
 			mainGroup = 7151D3DF2CE5970400620914;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				71B9EADA2CE70F430013F4BF /* XCRemoteSwiftPackageReference "SnapKit" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 7151D3E92CE5970400620914 /* Products */;
 			projectDirPath = "";
@@ -561,6 +578,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		71B9EADA2CE70F430013F4BF /* XCRemoteSwiftPackageReference "SnapKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 5.7.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		71B9EADC2CE70FEB0013F4BF /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 71B9EADA2CE70F430013F4BF /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 7151D3E02CE5970400620914 /* Project object */;
 }

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.pbxproj
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.pbxproj
@@ -1,0 +1,566 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		7151D3FF2CE5970500620914 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7151D3E02CE5970400620914 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7151D3E72CE5970400620914;
+			remoteInfo = "CalculatorApp-Codebase";
+		};
+		7151D4092CE5970500620914 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7151D3E02CE5970400620914 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7151D3E72CE5970400620914;
+			remoteInfo = "CalculatorApp-Codebase";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7151D3E82CE5970400620914 /* CalculatorApp-Codebase.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "CalculatorApp-Codebase.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7151D3FE2CE5970500620914 /* CalculatorApp-CodebaseTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CalculatorApp-CodebaseTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7151D4082CE5970500620914 /* CalculatorApp-CodebaseUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CalculatorApp-CodebaseUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7151D4102CE5970500620914 /* Exceptions for "CalculatorApp-Codebase" folder in "CalculatorApp-Codebase" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7151D3E72CE5970400620914 /* CalculatorApp-Codebase */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7151D3EA2CE5970400620914 /* CalculatorApp-Codebase */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7151D4102CE5970500620914 /* Exceptions for "CalculatorApp-Codebase" folder in "CalculatorApp-Codebase" target */,
+			);
+			path = "CalculatorApp-Codebase";
+			sourceTree = "<group>";
+		};
+		7151D4012CE5970500620914 /* CalculatorApp-CodebaseTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "CalculatorApp-CodebaseTests";
+			sourceTree = "<group>";
+		};
+		7151D40B2CE5970500620914 /* CalculatorApp-CodebaseUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "CalculatorApp-CodebaseUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7151D3E52CE5970400620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3FB2CE5970500620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D4052CE5970500620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7151D3DF2CE5970400620914 = {
+			isa = PBXGroup;
+			children = (
+				7151D3EA2CE5970400620914 /* CalculatorApp-Codebase */,
+				7151D4012CE5970500620914 /* CalculatorApp-CodebaseTests */,
+				7151D40B2CE5970500620914 /* CalculatorApp-CodebaseUITests */,
+				7151D3E92CE5970400620914 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7151D3E92CE5970400620914 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7151D3E82CE5970400620914 /* CalculatorApp-Codebase.app */,
+				7151D3FE2CE5970500620914 /* CalculatorApp-CodebaseTests.xctest */,
+				7151D4082CE5970500620914 /* CalculatorApp-CodebaseUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7151D3E72CE5970400620914 /* CalculatorApp-Codebase */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D4112CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-Codebase" */;
+			buildPhases = (
+				7151D3E42CE5970400620914 /* Sources */,
+				7151D3E52CE5970400620914 /* Frameworks */,
+				7151D3E62CE5970400620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				7151D3EA2CE5970400620914 /* CalculatorApp-Codebase */,
+			);
+			name = "CalculatorApp-Codebase";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-Codebase";
+			productReference = 7151D3E82CE5970400620914 /* CalculatorApp-Codebase.app */;
+			productType = "com.apple.product-type.application";
+		};
+		7151D3FD2CE5970500620914 /* CalculatorApp-CodebaseTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D4162CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-CodebaseTests" */;
+			buildPhases = (
+				7151D3FA2CE5970500620914 /* Sources */,
+				7151D3FB2CE5970500620914 /* Frameworks */,
+				7151D3FC2CE5970500620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7151D4002CE5970500620914 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7151D4012CE5970500620914 /* CalculatorApp-CodebaseTests */,
+			);
+			name = "CalculatorApp-CodebaseTests";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-CodebaseTests";
+			productReference = 7151D3FE2CE5970500620914 /* CalculatorApp-CodebaseTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		7151D4072CE5970500620914 /* CalculatorApp-CodebaseUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D4192CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-CodebaseUITests" */;
+			buildPhases = (
+				7151D4042CE5970500620914 /* Sources */,
+				7151D4052CE5970500620914 /* Frameworks */,
+				7151D4062CE5970500620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7151D40A2CE5970500620914 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7151D40B2CE5970500620914 /* CalculatorApp-CodebaseUITests */,
+			);
+			name = "CalculatorApp-CodebaseUITests";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-CodebaseUITests";
+			productReference = 7151D4082CE5970500620914 /* CalculatorApp-CodebaseUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7151D3E02CE5970400620914 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1610;
+				LastUpgradeCheck = 1610;
+				TargetAttributes = {
+					7151D3E72CE5970400620914 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+					7151D3FD2CE5970500620914 = {
+						CreatedOnToolsVersion = 16.1;
+						TestTargetID = 7151D3E72CE5970400620914;
+					};
+					7151D4072CE5970500620914 = {
+						CreatedOnToolsVersion = 16.1;
+						TestTargetID = 7151D3E72CE5970400620914;
+					};
+				};
+			};
+			buildConfigurationList = 7151D3E32CE5970400620914 /* Build configuration list for PBXProject "CalculatorApp-Codebase" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7151D3DF2CE5970400620914;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 7151D3E92CE5970400620914 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7151D3E72CE5970400620914 /* CalculatorApp-Codebase */,
+				7151D3FD2CE5970500620914 /* CalculatorApp-CodebaseTests */,
+				7151D4072CE5970500620914 /* CalculatorApp-CodebaseUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7151D3E62CE5970400620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3FC2CE5970500620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D4062CE5970500620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7151D3E42CE5970400620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3FA2CE5970500620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D4042CE5970500620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7151D4002CE5970500620914 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7151D3E72CE5970400620914 /* CalculatorApp-Codebase */;
+			targetProxy = 7151D3FF2CE5970500620914 /* PBXContainerItemProxy */;
+		};
+		7151D40A2CE5970500620914 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7151D3E72CE5970400620914 /* CalculatorApp-Codebase */;
+			targetProxy = 7151D4092CE5970500620914 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		7151D4122CE5970500620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CalculatorApp-Codebase/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-Codebase";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7151D4132CE5970500620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CalculatorApp-Codebase/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-Codebase";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		7151D4142CE5970500620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7151D4152CE5970500620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7151D4172CE5970500620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-CodebaseTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CalculatorApp-Codebase.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CalculatorApp-Codebase";
+			};
+			name = Debug;
+		};
+		7151D4182CE5970500620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-CodebaseTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CalculatorApp-Codebase.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CalculatorApp-Codebase";
+			};
+			name = Release;
+		};
+		7151D41A2CE5970500620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-CodebaseUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "CalculatorApp-Codebase";
+			};
+			name = Debug;
+		};
+		7151D41B2CE5970500620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-CodebaseUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "CalculatorApp-Codebase";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7151D3E32CE5970400620914 /* Build configuration list for PBXProject "CalculatorApp-Codebase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D4142CE5970500620914 /* Debug */,
+				7151D4152CE5970500620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D4112CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-Codebase" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D4122CE5970500620914 /* Debug */,
+				7151D4132CE5970500620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D4162CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-CodebaseTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D4172CE5970500620914 /* Debug */,
+				7151D4182CE5970500620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D4192CE5970500620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-CodebaseUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D41A2CE5970500620914 /* Debug */,
+				7151D41B2CE5970500620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7151D3E02CE5970400620914 /* Project object */;
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "dd27728c8848101841bd8d45243ef43144e233aa3767c82656934b73447347b8",
+  "pins" : [
+    {
+      "identity" : "snapkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SnapKit/SnapKit.git",
+      "state" : {
+        "revision" : "2842e6e84e82eb9a8dac0100ca90d9444b0307f4",
+        "version" : "5.7.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/xcuserdata/t0000-m0112.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase.xcodeproj/xcuserdata/t0000-m0112.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>CalculatorApp-Codebase.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/AppDelegate.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  CalculatorApp-Codebase
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/Contents.json
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/Base.lproj/LaunchScreen.storyboard
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/Info.plist
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/Info.plist
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
@@ -1,0 +1,57 @@
+//
+//  SceneDelegate.swift
+//  CalculatorApp-Codebase
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let windowScene = (scene as? UIWindowScene) else { return }
+        
+        let window = UIWindow(windowScene: windowScene)
+        window.rootViewController = ViewController()
+        window.makeKeyAndVisible()
+        self.window = window
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
@@ -11,11 +11,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
-        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
-        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
-        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = ViewController()

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/SceneDelegate.swift
@@ -17,7 +17,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
         guard let windowScene = (scene as? UIWindowScene) else { return }
-        
         let window = UIWindow(windowScene: windowScene)
         window.rootViewController = ViewController()
         window.makeKeyAndVisible()

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import SnapKit
 
 class ViewController: UIViewController {
 

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -10,53 +10,24 @@ import SnapKit
 
 class ViewController: UIViewController {
     
-    private enum HorizontalStack {
-        case row
-        
-        var stack: UIStackView {
-            let stack = UIStackView()
-            stack.axis = .horizontal
-            stack.backgroundColor = .black
-            stack.spacing = 10
-            stack.distribution = .fillEqually
-            return stack
-        }
-        
-        func makeConstraints(for stack: UIStackView) {
-            stack.snp.makeConstraints {
-                $0.centerX.equalToSuperview()
-                $0.height.equalTo(80)
-                $0.width.equalTo(350)
-            }
-        }
-    }
-    
     private enum CalculatorButton {
         case number(Int), operation(String), allClear, equal
         
         var title: String {
             switch self {
-            case .number(let value):
-                return "\(value)"
-            case .operation(let symbol):
-                return symbol
-            case .allClear:
-                return "AC"
-            case .equal:
-                return "="
+            case .number(let value): return "\(value)"
+            case .operation(let symbol): return symbol
+            case .allClear: return "AC"
+            case .equal: return "="
             }
         }
         
         var backgroundColor: UIColor {
             switch self {
-            case .number:
-                return .systemGray
-            case .operation:
-                return .systemOrange
-            case .allClear:
-                return .systemOrange
-            case .equal:
-                return .systemOrange
+            case .number: return .systemGray
+            case .operation: return .systemOrange
+            case .allClear: return .systemOrange
+            case .equal: return .systemOrange
             }
         }
         
@@ -75,12 +46,7 @@ class ViewController: UIViewController {
     
     private let expressionLabel = UILabel()
     private let superStack = UIStackView()
-    private let horizontalStacks: [UIStackView] = [
-        HorizontalStack.row.stack,
-        HorizontalStack.row.stack,
-        HorizontalStack.row.stack,
-        HorizontalStack.row.stack
-    ]
+    private let horizontalStacks: [UIStackView] = (0..<4).map { _ in UIStackView() }
     private let button0 = CalculatorButton.number(0).button
     private let button1 = CalculatorButton.number(1).button
     private let button2 = CalculatorButton.number(2).button
@@ -97,55 +63,68 @@ class ViewController: UIViewController {
     private let buttonDivide = CalculatorButton.operation("÷").button
     private let buttonAllClear = CalculatorButton.allClear.button
     private let buttonEqual = CalculatorButton.equal.button
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
         configureUI()
     }
-
+    
     private func configureUI() {
-        view.backgroundColor = .white
+        view.backgroundColor = .black
+        configureExpressionLabel()
+        configureSuperStack()
+        configureButton()
+    }
+    
+    private func configureExpressionLabel() {
         expressionLabel.backgroundColor = .black
         expressionLabel.text = "12345"
         expressionLabel.textColor = .white
         expressionLabel.textAlignment = .right
         expressionLabel.font = UIFont.boldSystemFont(ofSize: 60)
-        superStack.axis = .vertical
-        superStack.backgroundColor = .black
-        superStack.spacing = 10
-        superStack.distribution = .fillEqually
-        
-        [expressionLabel, superStack]
-            .forEach { view.addSubview($0) }
-        
+        view.addSubview(expressionLabel)
         expressionLabel.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(30)
             $0.trailing.equalToSuperview().offset(-30)
             $0.top.equalToSuperview().offset(200)
             $0.height.equalTo(100)
         }
-        
+    }
+    
+    private func configureSuperStack() {
+        superStack.axis = .vertical
+        superStack.backgroundColor = .black
+        superStack.spacing = 10
+        superStack.distribution = .fillEqually
+        view.addSubview(superStack)
         superStack.snp.makeConstraints {
             $0.centerX.equalToSuperview()
             $0.top.equalTo(expressionLabel.snp.bottom).offset(60)
             $0.width.equalTo(350)
         }
-
-        for stack in horizontalStacks {
-            superStack.addArrangedSubview(stack)
-            HorizontalStack.row.makeConstraints(for: stack)
-        }
         
+        horizontalStacks.forEach {
+            superStack.addArrangedSubview($0)
+            setupHorizontalStack(for: $0)
+        }
+    }
+    
+    private func setupHorizontalStack(for stack: UIStackView) {
+        stack.axis = .horizontal
+        stack.spacing = 10
+        stack.distribution = .fillEqually
+        stack.snp.makeConstraints {
+            $0.height.equalTo(80)
+        }
+    }
+    
+    private func configureButton() {
         [button7, button8, button9, buttonAdd]
             .forEach { horizontalStacks[0].addArrangedSubview($0) }
-        
         [button4, button5, button6, buttonSubtract]
             .forEach { horizontalStacks[1].addArrangedSubview($0) }
-        
         [button1, button2, button3, buttonMultiply]
             .forEach { horizontalStacks[2].addArrangedSubview($0) }
-        
         [buttonAllClear, button0, buttonEqual, buttonDivide]
             .forEach { horizontalStacks[3].addArrangedSubview($0) }
     }

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  CalculatorApp-Codebase
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -9,12 +9,148 @@ import UIKit
 import SnapKit
 
 class ViewController: UIViewController {
+    
+    private enum HorizontalStack {
+        case row
+        
+        var stack: UIStackView {
+            let stack = UIStackView()
+            stack.axis = .horizontal
+            stack.backgroundColor = .black
+            stack.spacing = 10
+            stack.distribution = .fillEqually
+            return stack
+        }
+        
+        func makeConstraints(for stack: UIStackView) {
+            stack.snp.makeConstraints {
+                $0.centerX.equalToSuperview()
+                $0.height.equalTo(80)
+                $0.width.equalTo(350)
+            }
+        }
+    }
+    
+    private enum CalculatorButton {
+        case number(Int), operation(String), allClear, equal
+        
+        var title: String {
+            switch self {
+            case .number(let value):
+                return "\(value)"
+            case .operation(let symbol):
+                return symbol
+            case .allClear:
+                return "AC"
+            case .equal:
+                return "="
+            }
+        }
+        
+        var backgroundColor: UIColor {
+            switch self {
+            case .number:
+                return .systemGray
+            case .operation:
+                return .systemOrange
+            case .allClear:
+                return .systemOrange
+            case .equal:
+                return .systemOrange
+            }
+        }
+        
+        var button: UIButton {
+            let button = UIButton()
+            button.frame.size.height = 80
+            button.frame.size.width = 80
+            button.layer.cornerRadius = 40
+            button.backgroundColor = self.backgroundColor
+            button.setTitle(self.title, for: .normal)
+            button.setTitleColor(.white, for: .normal)
+            button.titleLabel?.font = .boldSystemFont(ofSize: 30)
+            return button
+        }
+    }
+    
+    private let expressionLabel = UILabel()
+    private let superStack = UIStackView()
+    private let horizontalStacks: [UIStackView] = [
+        HorizontalStack.row.stack,
+        HorizontalStack.row.stack,
+        HorizontalStack.row.stack,
+        HorizontalStack.row.stack
+    ]
+    private let button0 = CalculatorButton.number(0).button
+    private let button1 = CalculatorButton.number(1).button
+    private let button2 = CalculatorButton.number(2).button
+    private let button3 = CalculatorButton.number(3).button
+    private let button4 = CalculatorButton.number(4).button
+    private let button5 = CalculatorButton.number(5).button
+    private let button6 = CalculatorButton.number(6).button
+    private let button7 = CalculatorButton.number(7).button
+    private let button8 = CalculatorButton.number(8).button
+    private let button9 = CalculatorButton.number(9).button
+    private let buttonAdd = CalculatorButton.operation("+").button
+    private let buttonSubtract = CalculatorButton.operation("-").button
+    private let buttonMultiply = CalculatorButton.operation("×").button
+    private let buttonDivide = CalculatorButton.operation("÷").button
+    private let buttonAllClear = CalculatorButton.allClear.button
+    private let buttonEqual = CalculatorButton.equal.button
 
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
+        configureUI()
     }
 
+    private func configureUI() {
+        view.backgroundColor = .white
+        expressionLabel.backgroundColor = .black
+        expressionLabel.text = "12345"
+        expressionLabel.textColor = .white
+        expressionLabel.textAlignment = .right
+        expressionLabel.font = UIFont.boldSystemFont(ofSize: 60)
+        superStack.axis = .vertical
+        superStack.backgroundColor = .black
+        superStack.spacing = 10
+        superStack.distribution = .fillEqually
+        
+        [expressionLabel, superStack]
+            .forEach { view.addSubview($0) }
+        
+        expressionLabel.snp.makeConstraints {
+            $0.leading.equalToSuperview().offset(30)
+            $0.trailing.equalToSuperview().offset(-30)
+            $0.top.equalToSuperview().offset(200)
+            $0.height.equalTo(100)
+        }
+        
+        superStack.snp.makeConstraints {
+            $0.centerX.equalToSuperview()
+            $0.top.equalTo(expressionLabel.snp.bottom).offset(60)
+            $0.width.equalTo(350)
+        }
 
+        for stack in horizontalStacks {
+            superStack.addArrangedSubview(stack)
+            HorizontalStack.row.makeConstraints(for: stack)
+        }
+        
+        [button7, button8, button9, buttonAdd]
+            .forEach { horizontalStacks[0].addArrangedSubview($0) }
+        
+        [button4, button5, button6, buttonSubtract]
+            .forEach { horizontalStacks[1].addArrangedSubview($0) }
+        
+        [button1, button2, button3, buttonMultiply]
+            .forEach { horizontalStacks[2].addArrangedSubview($0) }
+        
+        [buttonAllClear, button0, buttonEqual, buttonDivide]
+            .forEach { horizontalStacks[3].addArrangedSubview($0) }
+    }
 }
 
+#Preview {
+    ViewController()
+}

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -40,6 +40,7 @@ class ViewController: UIViewController {
             button.setTitle(self.title, for: .normal)
             button.setTitleColor(.white, for: .normal)
             button.titleLabel?.font = .boldSystemFont(ofSize: 30)
+            button.addTarget(self, action: #selector(buttonAction(from:)), for: .touchDown)
             return button
         }
     }
@@ -87,27 +88,29 @@ class ViewController: UIViewController {
     }
     
     // Button Actions:
-    @objc private func button0Action() { self.expression.append("0") }
-    @objc private func button1Action() { self.expression.append("1") }
-    @objc private func button2Action() { self.expression.append("2") }
-    @objc private func button3Action() { self.expression.append("3") }
-    @objc private func button4Action() { self.expression.append("4") }
-    @objc private func button5Action() { self.expression.append("5") }
-    @objc private func button6Action() { self.expression.append("6") }
-    @objc private func button7Action() { self.expression.append("7") }
-    @objc private func button8Action() { self.expression.append("8") }
-    @objc private func button9Action() { self.expression.append("9") }
-    @objc private func buttonAddAction() { self.expression.append("+") }
-    @objc private func buttonSubtractAction() { self.expression.append("-") }
-    @objc private func buttonMultiplyAction() { self.expression.append("×") }
-    @objc private func buttonDivideAction() { self.expression.append("÷") }
-    @objc private func buttonAllClearAction() { resetExpression() }
-    @objc private func buttonEqualAction() { if let result = calculate(expression) { expression = String(result) } }
-    
+    @objc private func buttonAction(from sender: UIButton) {
+        guard let buttonTitle = sender.titleLabel?.text else { return }
+
+        switch buttonTitle {
+        case "0", "1", "2", "3", "4", "5", "6", "7", "8", "9":
+            self.expression.append(buttonTitle)
+        case "+", "-", "×", "÷":
+            self.expression.append(buttonTitle)
+        case "AC":
+            resetExpression()
+        case "=":
+            if let result = calculate(expression) {
+                expression = String(result)
+            }
+        default:
+            break
+        }
+    }
+
     private func resetExpression() { self.expression = "0" }
         
     private func calculate(_ expression: String) -> Int? {
-        let expression = NSExpression(format: inputSanitization(expression))
+        let expression = NSExpression(format: changeMathSymbols(expression))
         if let result = expression.expressionValue(with: nil, context: nil) as? Int {
             return result
         } else {
@@ -115,8 +118,8 @@ class ViewController: UIViewController {
         }
     }
     
-    private func inputSanitization(_ expression: String) -> String {
-        expression // Change math symbols
+    private func changeMathSymbols(_ expression: String) -> String {
+        expression
             .replacingOccurrences(of: "×", with: "*")
             .replacingOccurrences(of: "÷", with: "/")
     }
@@ -174,23 +177,6 @@ class ViewController: UIViewController {
             .forEach { horizontalStacks[2].addArrangedSubview($0) }
         [buttonAllClear, button0, buttonEqual, buttonDivide]
             .forEach { horizontalStacks[3].addArrangedSubview($0) }
-        
-        button0.addTarget(self, action: #selector(button0Action), for: .touchDown)
-        button1.addTarget(self, action: #selector(button1Action), for: .touchDown)
-        button2.addTarget(self, action: #selector(button2Action), for: .touchDown)
-        button3.addTarget(self, action: #selector(button3Action), for: .touchDown)
-        button4.addTarget(self, action: #selector(button4Action), for: .touchDown)
-        button5.addTarget(self, action: #selector(button5Action), for: .touchDown)
-        button6.addTarget(self, action: #selector(button6Action), for: .touchDown)
-        button7.addTarget(self, action: #selector(button7Action), for: .touchDown)
-        button8.addTarget(self, action: #selector(button8Action), for: .touchDown)
-        button9.addTarget(self, action: #selector(button9Action), for: .touchDown)
-        buttonAdd.addTarget(self, action: #selector(buttonAddAction), for: .touchDown)
-        buttonSubtract.addTarget(self, action: #selector(buttonSubtractAction), for: .touchDown)
-        buttonMultiply.addTarget(self, action: #selector(buttonMultiplyAction), for: .touchDown)
-        buttonDivide.addTarget(self, action: #selector(buttonDivideAction), for: .touchDown)
-        buttonAllClear.addTarget(self, action: #selector(buttonAllClearAction), for: .touchDown)
-        buttonEqual.addTarget(self, action: #selector(buttonEqualAction), for: .touchDown)
     }
 }
 

--- a/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-Codebase/ViewController.swift
@@ -63,6 +63,16 @@ class ViewController: UIViewController {
     private let buttonDivide = CalculatorButton.operation("÷").button
     private let buttonAllClear = CalculatorButton.allClear.button
     private let buttonEqual = CalculatorButton.equal.button
+    private var expression = "0" {
+            didSet { // Exception Handling: Expressions that start with 0
+                if self.expression.count > 1 && self.expression[expression.startIndex] == "0" {
+                    if expression[expression.index(expression.startIndex, offsetBy: 1)].isNumber {
+                        self.expression.removeFirst()
+                    }
+                } // Update expressionLabel when value changed
+                self.expressionLabel.text = self.expression
+            }
+        }
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -76,9 +86,46 @@ class ViewController: UIViewController {
         configureButton()
     }
     
+    // Button Actions:
+    @objc private func button0Action() { self.expression.append("0") }
+    @objc private func button1Action() { self.expression.append("1") }
+    @objc private func button2Action() { self.expression.append("2") }
+    @objc private func button3Action() { self.expression.append("3") }
+    @objc private func button4Action() { self.expression.append("4") }
+    @objc private func button5Action() { self.expression.append("5") }
+    @objc private func button6Action() { self.expression.append("6") }
+    @objc private func button7Action() { self.expression.append("7") }
+    @objc private func button8Action() { self.expression.append("8") }
+    @objc private func button9Action() { self.expression.append("9") }
+    @objc private func buttonAddAction() { self.expression.append("+") }
+    @objc private func buttonSubtractAction() { self.expression.append("-") }
+    @objc private func buttonMultiplyAction() { self.expression.append("×") }
+    @objc private func buttonDivideAction() { self.expression.append("÷") }
+    @objc private func buttonAllClearAction() { resetExpression() }
+    @objc private func buttonEqualAction() { if let result = calculate(expression) { expression = String(result) } }
+    
+    private func resetExpression() { self.expression = "0" }
+        
+    private func calculate(_ expression: String) -> Int? {
+        let expression = NSExpression(format: inputSanitization(expression))
+        if let result = expression.expressionValue(with: nil, context: nil) as? Int {
+            return result
+        } else {
+            return nil
+        }
+    }
+    
+    private func inputSanitization(_ expression: String) -> String {
+        expression // Change math symbols
+            .replacingOccurrences(of: "×", with: "*")
+            .replacingOccurrences(of: "÷", with: "/")
+    }
+    
+    // UI Configurations:
+    
     private func configureExpressionLabel() {
         expressionLabel.backgroundColor = .black
-        expressionLabel.text = "12345"
+        expressionLabel.text = "0"
         expressionLabel.textColor = .white
         expressionLabel.textAlignment = .right
         expressionLabel.font = UIFont.boldSystemFont(ofSize: 60)
@@ -127,6 +174,23 @@ class ViewController: UIViewController {
             .forEach { horizontalStacks[2].addArrangedSubview($0) }
         [buttonAllClear, button0, buttonEqual, buttonDivide]
             .forEach { horizontalStacks[3].addArrangedSubview($0) }
+        
+        button0.addTarget(self, action: #selector(button0Action), for: .touchDown)
+        button1.addTarget(self, action: #selector(button1Action), for: .touchDown)
+        button2.addTarget(self, action: #selector(button2Action), for: .touchDown)
+        button3.addTarget(self, action: #selector(button3Action), for: .touchDown)
+        button4.addTarget(self, action: #selector(button4Action), for: .touchDown)
+        button5.addTarget(self, action: #selector(button5Action), for: .touchDown)
+        button6.addTarget(self, action: #selector(button6Action), for: .touchDown)
+        button7.addTarget(self, action: #selector(button7Action), for: .touchDown)
+        button8.addTarget(self, action: #selector(button8Action), for: .touchDown)
+        button9.addTarget(self, action: #selector(button9Action), for: .touchDown)
+        buttonAdd.addTarget(self, action: #selector(buttonAddAction), for: .touchDown)
+        buttonSubtract.addTarget(self, action: #selector(buttonSubtractAction), for: .touchDown)
+        buttonMultiply.addTarget(self, action: #selector(buttonMultiplyAction), for: .touchDown)
+        buttonDivide.addTarget(self, action: #selector(buttonDivideAction), for: .touchDown)
+        buttonAllClear.addTarget(self, action: #selector(buttonAllClearAction), for: .touchDown)
+        buttonEqual.addTarget(self, action: #selector(buttonEqualAction), for: .touchDown)
     }
 }
 

--- a/CalculatorApp-Codebase/CalculatorApp-CodebaseTests/CalculatorApp_CodebaseTests.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-CodebaseTests/CalculatorApp_CodebaseTests.swift
@@ -1,0 +1,17 @@
+//
+//  CalculatorApp_CodebaseTests.swift
+//  CalculatorApp-CodebaseTests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import Testing
+@testable import CalculatorApp_Codebase
+
+struct CalculatorApp_CodebaseTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/CalculatorApp-Codebase/CalculatorApp-CodebaseUITests/CalculatorApp_CodebaseUITests.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-CodebaseUITests/CalculatorApp_CodebaseUITests.swift
@@ -1,0 +1,43 @@
+//
+//  CalculatorApp_CodebaseUITests.swift
+//  CalculatorApp-CodebaseUITests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import XCTest
+
+final class CalculatorApp_CodebaseUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/CalculatorApp-Codebase/CalculatorApp-CodebaseUITests/CalculatorApp_CodebaseUITestsLaunchTests.swift
+++ b/CalculatorApp-Codebase/CalculatorApp-CodebaseUITests/CalculatorApp_CodebaseUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  CalculatorApp_CodebaseUITestsLaunchTests.swift
+//  CalculatorApp-CodebaseUITests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import XCTest
+
+final class CalculatorApp_CodebaseUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.pbxproj
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.pbxproj
@@ -1,0 +1,568 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXContainerItemProxy section */
+		7151D3722CE5953900620914 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7151D3532CE5953800620914 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7151D35A2CE5953800620914;
+			remoteInfo = "CalculatorApp-Storyboard";
+		};
+		7151D37C2CE5953900620914 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 7151D3532CE5953800620914 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 7151D35A2CE5953800620914;
+			remoteInfo = "CalculatorApp-Storyboard";
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXFileReference section */
+		7151D35B2CE5953800620914 /* CalculatorApp-Storyboard.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "CalculatorApp-Storyboard.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7151D3712CE5953900620914 /* CalculatorApp-StoryboardTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CalculatorApp-StoryboardTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7151D37B2CE5953900620914 /* CalculatorApp-StoryboardUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "CalculatorApp-StoryboardUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		7151D3832CE5953900620914 /* Exceptions for "CalculatorApp-Storyboard" folder in "CalculatorApp-Storyboard" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = 7151D35A2CE5953800620914 /* CalculatorApp-Storyboard */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		7151D35D2CE5953800620914 /* CalculatorApp-Storyboard */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				7151D3832CE5953900620914 /* Exceptions for "CalculatorApp-Storyboard" folder in "CalculatorApp-Storyboard" target */,
+			);
+			path = "CalculatorApp-Storyboard";
+			sourceTree = "<group>";
+		};
+		7151D3742CE5953900620914 /* CalculatorApp-StoryboardTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "CalculatorApp-StoryboardTests";
+			sourceTree = "<group>";
+		};
+		7151D37E2CE5953900620914 /* CalculatorApp-StoryboardUITests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = "CalculatorApp-StoryboardUITests";
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7151D3582CE5953800620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D36E2CE5953900620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3782CE5953900620914 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7151D3522CE5953800620914 = {
+			isa = PBXGroup;
+			children = (
+				7151D35D2CE5953800620914 /* CalculatorApp-Storyboard */,
+				7151D3742CE5953900620914 /* CalculatorApp-StoryboardTests */,
+				7151D37E2CE5953900620914 /* CalculatorApp-StoryboardUITests */,
+				7151D35C2CE5953800620914 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7151D35C2CE5953800620914 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7151D35B2CE5953800620914 /* CalculatorApp-Storyboard.app */,
+				7151D3712CE5953900620914 /* CalculatorApp-StoryboardTests.xctest */,
+				7151D37B2CE5953900620914 /* CalculatorApp-StoryboardUITests.xctest */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7151D35A2CE5953800620914 /* CalculatorApp-Storyboard */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D3842CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-Storyboard" */;
+			buildPhases = (
+				7151D3572CE5953800620914 /* Sources */,
+				7151D3582CE5953800620914 /* Frameworks */,
+				7151D3592CE5953800620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				7151D35D2CE5953800620914 /* CalculatorApp-Storyboard */,
+			);
+			name = "CalculatorApp-Storyboard";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-Storyboard";
+			productReference = 7151D35B2CE5953800620914 /* CalculatorApp-Storyboard.app */;
+			productType = "com.apple.product-type.application";
+		};
+		7151D3702CE5953900620914 /* CalculatorApp-StoryboardTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D3892CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-StoryboardTests" */;
+			buildPhases = (
+				7151D36D2CE5953900620914 /* Sources */,
+				7151D36E2CE5953900620914 /* Frameworks */,
+				7151D36F2CE5953900620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7151D3732CE5953900620914 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7151D3742CE5953900620914 /* CalculatorApp-StoryboardTests */,
+			);
+			name = "CalculatorApp-StoryboardTests";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-StoryboardTests";
+			productReference = 7151D3712CE5953900620914 /* CalculatorApp-StoryboardTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		7151D37A2CE5953900620914 /* CalculatorApp-StoryboardUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7151D38C2CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-StoryboardUITests" */;
+			buildPhases = (
+				7151D3772CE5953900620914 /* Sources */,
+				7151D3782CE5953900620914 /* Frameworks */,
+				7151D3792CE5953900620914 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				7151D37D2CE5953900620914 /* PBXTargetDependency */,
+			);
+			fileSystemSynchronizedGroups = (
+				7151D37E2CE5953900620914 /* CalculatorApp-StoryboardUITests */,
+			);
+			name = "CalculatorApp-StoryboardUITests";
+			packageProductDependencies = (
+			);
+			productName = "CalculatorApp-StoryboardUITests";
+			productReference = 7151D37B2CE5953900620914 /* CalculatorApp-StoryboardUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7151D3532CE5953800620914 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1610;
+				LastUpgradeCheck = 1610;
+				TargetAttributes = {
+					7151D35A2CE5953800620914 = {
+						CreatedOnToolsVersion = 16.1;
+					};
+					7151D3702CE5953900620914 = {
+						CreatedOnToolsVersion = 16.1;
+						TestTargetID = 7151D35A2CE5953800620914;
+					};
+					7151D37A2CE5953900620914 = {
+						CreatedOnToolsVersion = 16.1;
+						TestTargetID = 7151D35A2CE5953800620914;
+					};
+				};
+			};
+			buildConfigurationList = 7151D3562CE5953800620914 /* Build configuration list for PBXProject "CalculatorApp-Storyboard" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7151D3522CE5953800620914;
+			minimizedProjectReferenceProxies = 1;
+			preferredProjectObjectVersion = 77;
+			productRefGroup = 7151D35C2CE5953800620914 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7151D35A2CE5953800620914 /* CalculatorApp-Storyboard */,
+				7151D3702CE5953900620914 /* CalculatorApp-StoryboardTests */,
+				7151D37A2CE5953900620914 /* CalculatorApp-StoryboardUITests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7151D3592CE5953800620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D36F2CE5953900620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3792CE5953900620914 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7151D3572CE5953800620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D36D2CE5953900620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		7151D3772CE5953900620914 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		7151D3732CE5953900620914 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7151D35A2CE5953800620914 /* CalculatorApp-Storyboard */;
+			targetProxy = 7151D3722CE5953900620914 /* PBXContainerItemProxy */;
+		};
+		7151D37D2CE5953900620914 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 7151D35A2CE5953800620914 /* CalculatorApp-Storyboard */;
+			targetProxy = 7151D37C2CE5953900620914 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin XCBuildConfiguration section */
+		7151D3852CE5953900620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CalculatorApp-Storyboard/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-Storyboard";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7151D3862CE5953900620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "CalculatorApp-Storyboard/Info.plist";
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-Storyboard";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		7151D3872CE5953900620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7151D3882CE5953900620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7151D38A2CE5953900620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-StoryboardTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CalculatorApp-Storyboard.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CalculatorApp-Storyboard";
+			};
+			name = Debug;
+		};
+		7151D38B2CE5953900620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-StoryboardTests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CalculatorApp-Storyboard.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/CalculatorApp-Storyboard";
+			};
+			name = Release;
+		};
+		7151D38D2CE5953900620914 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-StoryboardUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "CalculatorApp-Storyboard";
+			};
+			name = Debug;
+		};
+		7151D38E2CE5953900620914 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.DoyleHWorks.CalculatorApp-StoryboardUITests";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = NO;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = "CalculatorApp-Storyboard";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7151D3562CE5953800620914 /* Build configuration list for PBXProject "CalculatorApp-Storyboard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D3872CE5953900620914 /* Debug */,
+				7151D3882CE5953900620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D3842CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-Storyboard" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D3852CE5953900620914 /* Debug */,
+				7151D3862CE5953900620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D3892CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-StoryboardTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D38A2CE5953900620914 /* Debug */,
+				7151D38B2CE5953900620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7151D38C2CE5953900620914 /* Build configuration list for PBXNativeTarget "CalculatorApp-StoryboardUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7151D38D2CE5953900620914 /* Debug */,
+				7151D38E2CE5953900620914 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7151D3532CE5953800620914 /* Project object */;
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.xcworkspace/xcuserdata/t0000-m0112.xcuserdatad/Bookmarks/bookmarks.plist
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/project.xcworkspace/xcuserdata/t0000-m0112.xcuserdatad/Bookmarks/bookmarks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>top-level-items</key>
+	<array/>
+</dict>
+</plist>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/xcuserdata/t0000-m0112.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard.xcodeproj/xcuserdata/t0000-m0112.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SchemeUserState</key>
+	<dict>
+		<key>CalculatorApp-Storyboard.xcscheme_^#shared#^_</key>
+		<dict>
+			<key>orderHint</key>
+			<integer>0</integer>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/AppDelegate.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/AppDelegate.swift
@@ -1,0 +1,36 @@
+//
+//  AppDelegate.swift
+//  CalculatorApp-Storyboard
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/Contents.json
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/LaunchScreen.storyboard
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/LaunchScreen.storyboard
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/LaunchScreen.storyboard
@@ -7,7 +7,7 @@
     </dependencies>
     <scenes>
         <!--View Controller-->
-        <scene sceneID="EHf-IW-A2E">
+        <scene sceneID="EHf-fjscW-A2E">
             <objects>
                 <viewController id="01J-lp-oVM" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
@@ -1,24 +1,381 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina6_12" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
-        <scene sceneID="tne-QT-ifu">
+        <scene sceneID="EHf-IW-A2E">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
-                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="CalculatorApp_Storyboard" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2x-vd-F9P">
+                                <rect key="frame" x="30" y="259" width="333" height="100"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="100" id="10e-g9-2ps"/>
+                                </constraints>
+                                <fontDescription key="fontDescription" type="boldSystem" pointSize="60"/>
+                                <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="TLx-Ps-wKI">
+                                <rect key="frame" x="21.666666666666657" y="419" width="350" height="350"/>
+                                <subviews>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="Fx0-d5-Bty" userLabel="Stack View - H1">
+                                        <rect key="frame" x="0.0" y="0.0" width="350" height="80"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x4u-sY-yhy">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="Iam-Xc-avC"/>
+                                                    <constraint firstAttribute="width" constant="80" id="ZNd-Rb-ANm"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="7">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zve-5s-nfb">
+                                                <rect key="frame" x="90" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="H87-P5-xim"/>
+                                                    <constraint firstAttribute="height" constant="80" id="tPF-PZ-vWV"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="8">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GFH-mo-vMx">
+                                                <rect key="frame" x="180" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="d5b-Cn-80V"/>
+                                                    <constraint firstAttribute="width" constant="80" id="zf4-d4-3EO"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="9">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JBZ-Vy-2hd">
+                                                <rect key="frame" x="270" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="JyU-ka-FuL"/>
+                                                    <constraint firstAttribute="width" constant="80" id="Rln-BZ-Ztq"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="+">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="XRB-Vs-NT9"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="hUX-At-gPG" userLabel="Stack View - H2">
+                                        <rect key="frame" x="0.0" y="90" width="350" height="80"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="o1i-oY-ztn">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="a5R-17-Doy"/>
+                                                    <constraint firstAttribute="width" constant="80" id="g0c-aQ-YDP"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="4">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucv-8B-qS0">
+                                                <rect key="frame" x="90" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="1nA-06-D8c"/>
+                                                    <constraint firstAttribute="height" constant="80" id="KAy-bb-HWQ"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="5">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uLs-dp-BTp">
+                                                <rect key="frame" x="180" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="5Yx-XY-yIh"/>
+                                                    <constraint firstAttribute="height" constant="80" id="h65-8V-6Q3"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="6">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WwT-dL-09w">
+                                                <rect key="frame" x="270" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="44U-3p-4W7"/>
+                                                    <constraint firstAttribute="width" constant="80" id="UfC-m6-cDp"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="-">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="fpK-K5-ZJT"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="h9R-ss-hy1" userLabel="Stack View - H3">
+                                        <rect key="frame" x="0.0" y="180" width="350" height="80"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="9y1-JD-MBe">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="GPv-js-mNH"/>
+                                                    <constraint firstAttribute="height" constant="80" id="psL-3u-V7q"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="1">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wjU-qM-H3T">
+                                                <rect key="frame" x="90" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="P5s-ig-4d7"/>
+                                                    <constraint firstAttribute="height" constant="80" id="mEm-7d-vfU"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="2">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gn8-tw-TPY">
+                                                <rect key="frame" x="180" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="BnA-Ew-qTc"/>
+                                                    <constraint firstAttribute="height" constant="80" id="RF2-1p-EDK"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="3">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v0Y-VP-8gp">
+                                                <rect key="frame" x="270" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="6eH-Em-8lD"/>
+                                                    <constraint firstAttribute="height" constant="80" id="Pyz-QF-UdJ"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="×">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="lmn-E1-JTs"/>
+                                        </constraints>
+                                    </stackView>
+                                    <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="ahc-c9-v7r" userLabel="Stack View - H4">
+                                        <rect key="frame" x="0.0" y="270" width="350" height="80"/>
+                                        <subviews>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="oW4-yZ-oQv">
+                                                <rect key="frame" x="0.0" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="BB1-ST-FHb"/>
+                                                    <constraint firstAttribute="width" constant="80" id="tKG-DU-IFJ"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="AC">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i0f-qr-0AX">
+                                                <rect key="frame" x="90" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemGrayColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="6GD-Rx-sh6"/>
+                                                    <constraint firstAttribute="width" constant="80" id="HXj-Fe-hfO"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="0">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KsT-bg-JO4">
+                                                <rect key="frame" x="180" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="80" id="BDR-td-ojW"/>
+                                                    <constraint firstAttribute="height" constant="80" id="kjD-LT-2qR"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="=">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2vh-hT-Xlz">
+                                                <rect key="frame" x="270" y="0.0" width="80" height="80"/>
+                                                <color key="backgroundColor" systemColor="systemOrangeColor"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="height" constant="80" id="Td3-KN-sug"/>
+                                                    <constraint firstAttribute="width" constant="80" id="gWa-vg-Mhk"/>
+                                                </constraints>
+                                                <state key="normal" title="Button"/>
+                                                <buttonConfiguration key="configuration" style="plain" title="÷">
+                                                    <fontDescription key="titleFontDescription" type="boldSystem" pointSize="30"/>
+                                                    <color key="baseForegroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                </buttonConfiguration>
+                                                <userDefinedRuntimeAttributes>
+                                                    <userDefinedRuntimeAttribute type="number" keyPath="layer.cornerRadius">
+                                                        <integer key="value" value="40"/>
+                                                    </userDefinedRuntimeAttribute>
+                                                </userDefinedRuntimeAttributes>
+                                            </button>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="80" id="DcL-4p-Efx"/>
+                                        </constraints>
+                                    </stackView>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="350" id="v3b-ZE-CZw"/>
+                                </constraints>
+                            </stackView>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <constraints>
+                            <constraint firstItem="a2x-vd-F9P" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="200" id="UKt-8N-I71"/>
+                            <constraint firstItem="6Tk-OE-BBY" firstAttribute="trailing" secondItem="a2x-vd-F9P" secondAttribute="trailing" constant="30" id="UMq-jz-xK6"/>
+                            <constraint firstItem="TLx-Ps-wKI" firstAttribute="top" secondItem="a2x-vd-F9P" secondAttribute="bottom" constant="60" id="alK-ye-DbF"/>
+                            <constraint firstItem="a2x-vd-F9P" firstAttribute="leading" secondItem="6Tk-OE-BBY" secondAttribute="leading" constant="30" id="tSx-Yg-uFM"/>
+                            <constraint firstItem="TLx-Ps-wKI" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="zvQ-Qm-vNI"/>
+                        </constraints>
                     </view>
                 </viewController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="52.671755725190835" y="374.64788732394368"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemGrayColor">
+            <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemOrangeColor">
+            <color red="1" green="0.58431372550000005" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+    </resources>
 </document>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Base.lproj/Main.storyboard
@@ -16,7 +16,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12345" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2x-vd-F9P">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0" textAlignment="right" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="a2x-vd-F9P">
                                 <rect key="frame" x="30" y="259" width="333" height="100"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="100" id="10e-g9-2ps"/>
@@ -48,6 +48,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="sevenButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="sS6-fW-IYJ"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Zve-5s-nfb">
                                                 <rect key="frame" x="90" y="0.0" width="80" height="80"/>
@@ -66,6 +69,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="eightButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Bw3-i5-Qd2"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="GFH-mo-vMx">
                                                 <rect key="frame" x="180" y="0.0" width="80" height="80"/>
@@ -84,6 +90,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="nineButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="MVj-JF-9Vd"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JBZ-Vy-2hd">
                                                 <rect key="frame" x="270" y="0.0" width="80" height="80"/>
@@ -102,6 +111,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="addButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="aLT-hN-JTw"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>
@@ -128,6 +140,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="fourButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Zsr-s3-26D"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ucv-8B-qS0">
                                                 <rect key="frame" x="90" y="0.0" width="80" height="80"/>
@@ -146,6 +161,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="fiveButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ZUS-tr-Etm"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="uLs-dp-BTp">
                                                 <rect key="frame" x="180" y="0.0" width="80" height="80"/>
@@ -164,6 +182,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="sixButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="IBS-86-OBq"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WwT-dL-09w">
                                                 <rect key="frame" x="270" y="0.0" width="80" height="80"/>
@@ -182,6 +203,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="subtractButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="4dO-4C-w1b"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>
@@ -208,6 +232,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="oneButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="qCi-qe-roV"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="wjU-qM-H3T">
                                                 <rect key="frame" x="90" y="0.0" width="80" height="80"/>
@@ -226,6 +253,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="twoButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="kU7-Fv-uYO"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Gn8-tw-TPY">
                                                 <rect key="frame" x="180" y="0.0" width="80" height="80"/>
@@ -244,6 +274,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="threeButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Kwz-Qv-Ho2"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="v0Y-VP-8gp">
                                                 <rect key="frame" x="270" y="0.0" width="80" height="80"/>
@@ -262,6 +295,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="multiplyButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="tdD-t5-sKA"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>
@@ -288,6 +324,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="allClearButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="adC-hm-Qke"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i0f-qr-0AX">
                                                 <rect key="frame" x="90" y="0.0" width="80" height="80"/>
@@ -306,6 +345,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="zeroButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="UJe-0H-Iut"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="KsT-bg-JO4">
                                                 <rect key="frame" x="180" y="0.0" width="80" height="80"/>
@@ -324,6 +366,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="equalButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Pen-b7-JOD"/>
+                                                </connections>
                                             </button>
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2vh-hT-Xlz">
                                                 <rect key="frame" x="270" y="0.0" width="80" height="80"/>
@@ -342,6 +387,9 @@
                                                         <integer key="value" value="40"/>
                                                     </userDefinedRuntimeAttribute>
                                                 </userDefinedRuntimeAttributes>
+                                                <connections>
+                                                    <action selector="divideButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="FDh-mU-ptf"/>
+                                                </connections>
                                             </button>
                                         </subviews>
                                         <constraints>
@@ -364,6 +412,9 @@
                             <constraint firstItem="TLx-Ps-wKI" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="zvQ-Qm-vNI"/>
                         </constraints>
                     </view>
+                    <connections>
+                        <outlet property="expressionLabel" destination="a2x-vd-F9P" id="3f1-mq-Pqc"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Info.plist
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/SceneDelegate.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/SceneDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  SceneDelegate.swift
+//  CalculatorApp-Storyboard
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/ViewController.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/ViewController.swift
@@ -1,0 +1,19 @@
+//
+//  ViewController.swift
+//  CalculatorApp-Storyboard
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/CalculatorApp-Storyboard/CalculatorApp-Storyboard/ViewController.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-Storyboard/ViewController.swift
@@ -8,12 +8,63 @@
 import UIKit
 
 class ViewController: UIViewController {
-
+    
+    @IBOutlet weak var expressionLabel: UILabel!
+    @IBAction func zeroButtonAction(_ sender: Any) { self.expression.append("0") }
+    @IBAction func oneButtonAction(_ sender: Any) { self.expression.append("1") }
+    @IBAction func twoButtonAction(_ sender: Any) { self.expression.append("2") }
+    @IBAction func threeButtonAction(_ sender: Any) { self.expression.append("3") }
+    @IBAction func fourButtonAction(_ sender: Any) { self.expression.append("4") }
+    @IBAction func fiveButtonAction(_ sender: Any) { self.expression.append("5") }
+    @IBAction func sixButtonAction(_ sender: Any) { self.expression.append("6") }
+    @IBAction func sevenButtonAction(_ sender: Any) { self.expression.append("7") }
+    @IBAction func eightButtonAction(_ sender: Any) { self.expression.append("8") }
+    @IBAction func nineButtonAction(_ sender: Any) { self.expression.append("9") }
+    @IBAction func addButtonAction(_ sender: Any) { self.expression.append("+") }
+    @IBAction func subtractButtonAction(_ sender: Any) { self.expression.append("-") }
+    @IBAction func multiplyButtonAction(_ sender: Any) { self.expression.append("×") }
+    @IBAction func divideButtonAction(_ sender: Any) { self.expression.append("÷") }
+    @IBAction func allClearButtonAction(_ sender: Any) { resetExpression() }
+    @IBAction func equalButtonAction(_ sender: Any) {
+        if let result = calculate(expression) {
+            self.expression = String(result)
+        } else {
+            self.expression = "Error"
+        }
+    }
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
+    
+    private var expression = "0" {
+        didSet {
+            if self.expression.count > 1 && self.expression[expression.startIndex] == "0" {
+                if expression[expression.index(expression.startIndex, offsetBy: 1)].isNumber {
+                    self.expression.removeFirst()
+                }
+            }
+            self.expressionLabel.text = self.expression
+        }
+    }
+    
+    private func resetExpression() { self.expression = "0" }
+    
+    private func calculate(_ expression: String) -> Int? {
+        let expression = NSExpression(format: inputSanitization(expression))
+        if let result = expression.expressionValue(with: nil, context: nil) as? Int {
+            return result
+        } else {
+            return nil
+        }
+    }
+    
+    private func inputSanitization(_ expression: String) -> String {
+        expression
+            .replacingOccurrences(of: "×", with: "*")
+            .replacingOccurrences(of: "÷", with: "/")
+    }
+    
 }
 

--- a/CalculatorApp-Storyboard/CalculatorApp-StoryboardTests/CalculatorApp_StoryboardTests.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-StoryboardTests/CalculatorApp_StoryboardTests.swift
@@ -1,0 +1,17 @@
+//
+//  CalculatorApp_StoryboardTests.swift
+//  CalculatorApp-StoryboardTests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import Testing
+@testable import CalculatorApp_Storyboard
+
+struct CalculatorApp_StoryboardTests {
+
+    @Test func example() async throws {
+        // Write your test here and use APIs like `#expect(...)` to check expected conditions.
+    }
+
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-StoryboardUITests/CalculatorApp_StoryboardUITests.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-StoryboardUITests/CalculatorApp_StoryboardUITests.swift
@@ -1,0 +1,43 @@
+//
+//  CalculatorApp_StoryboardUITests.swift
+//  CalculatorApp-StoryboardUITests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import XCTest
+
+final class CalculatorApp_StoryboardUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+
+        // In UI tests it is usually best to stop immediately when a failure occurs.
+        continueAfterFailure = false
+
+        // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    @MainActor
+    func testExample() throws {
+        // UI tests must launch the application that they test.
+        let app = XCUIApplication()
+        app.launch()
+
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    @MainActor
+    func testLaunchPerformance() throws {
+        if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 7.0, *) {
+            // This measures how long it takes to launch your application.
+            measure(metrics: [XCTApplicationLaunchMetric()]) {
+                XCUIApplication().launch()
+            }
+        }
+    }
+}

--- a/CalculatorApp-Storyboard/CalculatorApp-StoryboardUITests/CalculatorApp_StoryboardUITestsLaunchTests.swift
+++ b/CalculatorApp-Storyboard/CalculatorApp-StoryboardUITests/CalculatorApp_StoryboardUITestsLaunchTests.swift
@@ -1,0 +1,33 @@
+//
+//  CalculatorApp_StoryboardUITestsLaunchTests.swift
+//  CalculatorApp-StoryboardUITests
+//
+//  Created by t0000-m0112 on 2024-11-14.
+//
+
+import XCTest
+
+final class CalculatorApp_StoryboardUITestsLaunchTests: XCTestCase {
+
+    override class var runsForEachTargetApplicationUIConfiguration: Bool {
+        true
+    }
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testLaunch() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        // Insert steps here to perform after app launch but before taking a screenshot,
+        // such as logging into a test account or navigating somewhere in the app
+
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = "Launch Screen"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
# Codebase.Ver.0.0.8
- CalculatorApp-Storyboard Ver.0.0.8 (Lv.8) 파일이 포함됨
- CalculatorApp-Codebase Ver.0.0.8 (Lv.8)

## CalculatorApp-Storyboard Ver.0.0.8 (Lv.8)
숫자와 연산자 버튼을 누를 때마다 `expression` 문자열에 추가하고, 이를 화면(expressionLabel)에 표시한다.
"=" 버튼을 누르면 수식을 계산하여 결과를 표시하며, "AC" 버튼으로 초기화한다. 
곱셈(`×`)과 나눗셈(`÷`)은 실제 계산을 위해 `*`, `/`로 변환된다.

![image](https://github.com/user-attachments/assets/4c6fba3c-4cf3-40c5-983f-ae5cfc953c04)

## CalculatorApp-Codebase Ver.0.0.8 (Lv.8)

### 🎛️ **열거형을 활용한 버튼 관리 (`CalculatorButton`)**
- `enum CalculatorButton`으로 버튼의 상태를 정의:
  - **숫자 버튼**과 **연산자 버튼**을 동일한 열거형으로 관리.
  - 각 버튼의 **타이틀, 배경색** 등을 프로퍼티로 제공.
  - **`button` 프로퍼티**를 통해 버튼 인스턴스를 생성하여 일관성 있는 설정 제공.
  - **객체 지향 원칙 활용**: 중복되는 버튼 설정(프레임, 색상, 텍스트 스타일)을 열거형 내부에서 한 번만 정의하여 중복 코드 최소화.

### 🔄 **버튼 액션 처리의 통합적 구현**
- **모든 버튼의 액션을 `buttonAction` 메서드로 통합**:
  - `UIButton`의 **타이틀 기반으로 동작 결정** (`titleLabel?.text`).
  - **숫자와 연산자 구분 없이 동일한 메서드**에서 처리.
  - `switch` 문을 활용하여 각 버튼의 기능(숫자 추가, 연산자 추가, 초기화, 계산) 실행.
  - **선언형 접근법**: 버튼마다 개별 메서드를 만드는 대신, 액션 메서드를 하나로 통합하여 유지보수성 강화.

### 🖋️ **`didSet`를 활용한 표현식 업데이트**
- **`expression` 프로퍼티에 `didSet` 사용**:
  - **상태 변화 감지**: `expression`이 변경될 때마다 라벨에 자동으로 반영.
  - **숫자 입력 예외 처리**: `0`으로 시작하는 표현식을 자동 정리(두 번째 문자가 숫자일 경우 첫 번째 `0` 제거).

### 📐 **동적 레이아웃 설정 (`SnapKit`)**
- **Stack View**:
  - 수직 스택(superStack)을 상위 컨테이너로 두고, 내부에 4개의 **수평 스택**을 배치.
  - 각 수평 스택에 버튼 4개씩 배치하여 계산기의 숫자 및 연산자 버튼을 균일하게 정렬.
- **SnapKit의 제약 조건 사용**:
  - **수평 스택 간 간격** 및 각 버튼의 크기를 동적으로 조정.
  - 화면 크기에 따라 적절한 버튼 배치가 자동 조정되도록 설정.

### 🧮 **`NSExpression`을 활용한 수식 평가**
- 수식 계산은 `NSExpression`을 활용하여 문자열 수식을 평가:
  - 입력된 수식을 단순히 텍스트가 아닌 **실제 수식으로 변환**하여 계산.
  - **커스텀 기호(`×`, `÷`)를 표준 수학 기호(`*`, `/`)로 변환**하는 전처리 함수(`changeMathSymbols`) 포함.
  - `NSExpression`의 내장 계산 기능을 사용하여 **간결하고 안전한 계산 로직** 구현.
